### PR TITLE
Better code completion inside classes and for abstract classes

### DIFF
--- a/ftplugin/phpcomplete.vim
+++ b/ftplugin/phpcomplete.vim
@@ -164,14 +164,15 @@ function! phpcomplete#CompletePHP(findstart, base)
 				let classcontent = ''
 				let classcontent .= "\n".phpcomplete#GetClassContents(classfile, classname)
 				let sccontent = split(classcontent, "\n")
+                let classAccess = expand('%:p') == fnamemodify(classlocation, ':p') ? '\\(public\\|private\\|protected\\)' : 'public'
 
 				" limit based on context to static or normal public methods
 				if scontext =~ '::'
 					let functions = filter(deepcopy(sccontent),
-							\ 'v:val =~ "^\\s*\\(\\(public\\s\\+static\\|static\\)\\s\\+\\)*function"')
+							\ 'v:val =~ "^\\s*\\(\\(' . classAccess . '\\s\\+static\\|static\\)\\s\\+\\)*function"')
 				elseif scontext =~ '->$'
 					let functions = filter(deepcopy(sccontent),
-							\ 'v:val =~ "^\\s*\\(public\\s\\+\\)*function"')
+							\ 'v:val =~ "^\\s*\\(' . classAccess . '\\s\\+\\)*function"')
 				endif
 
 				let jfuncs = join(functions, ' ')
@@ -189,7 +190,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 				" Variables declared with var or with public keyword are
 				" public
 				let variables = filter(deepcopy(sccontent),
-						\ 'v:val =~ "^\\s*\\(public\\|var\\)\\s\\+\\$"')
+						\ 'v:val =~ "^\\s*\\(' . classAccess . '\\|var\\)\\s\\+\\$"')
 				let jvars = join(variables, ' ')
 				let svars = split(jvars, '\$')
 				let c_variables = {}
@@ -692,7 +693,7 @@ function! phpcomplete#GetClassLocation(classname) " {{{
 	while i < line('.')
 		let line = getline(line('.')-i)
 		if line =~ '^\s*class ' . a:classname  . '\(\s\+\|$\)'
-			return expand('%')
+			return expand('%:p')
 		else
 			let i += 1
 			continue


### PR DESCRIPTION
Completion on $this-> and for self:: was not working properly inside abstract classes. This patch fixes that...

Completion inside a class never returned private/public methods / members. The patch now correctly returns protected and private members when inside a class.
