### PR TITLE
Add the "info" key's value to "menu" as well

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -66,7 +66,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 
 	let scontext = substitute(context, '\$\?[a-zA-Z_\x7f-\xff][a-zA-Z_0-9\x7f-\xff]*$', '', '')
 
-	if scontext =~ '\(=\s*new\|extends\)\s\+$'
+	if scontext =~ '\(\s*new\|extends\)\s\+$'
 		" Complete class name
 		" Internal solution for finding classes in current file.
 		let file = getline(1, '$')
@@ -120,7 +120,11 @@ function! phpcomplete#CompletePHP(findstart, base)
 
 		let final_menu = []
 		for i in res
-			let final_menu += [{'word':i, 'kind':'c'}]
+			let menu = ''
+			if (has_key(g:php_builtin_object_functions, i.'::__construct('))
+				let menu = g:php_builtin_object_functions[i.'::__construct(']
+			endif
+			let final_menu += [{'word':i, 'kind':'c', 'menu':menu}]
 		endfor
 
 		return final_menu
@@ -151,6 +155,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 				for object in keys(g:php_builtin_object_functions)
 					if object =~ '^'.classname
 						let res += [{'word':substitute(object, '.*::', '', ''),
+							   	\    'menu': g:php_builtin_object_functions[object],
 							   	\    'info': g:php_builtin_object_functions[object]}]
 					endif
 				endfor
@@ -243,11 +248,13 @@ function! phpcomplete#CompletePHP(findstart, base)
 						let final_list +=
 								\ [{'word':i,
 								\   'info':class.all_values[i],
+								\   'menu':class.all_values[i],
 								\   'kind':'v'}]
 					else
 						let final_list +=
 								\ [{'word':substitute(i, '.*::', '', ''),
 								\   'info':i.all_values[i].')',
+								\   'menu':i.all_values[i].')',
 								\   'kind':'f'}]
 					endif
 				endfor
@@ -363,6 +370,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 				let final_list +=
 						\ [{'word':substitute(i, '.*::', '', ''),
 						\   'info':i.all_values[i],
+						\   'menu':i.all_values[i],
 						\   'kind':'f'}]
 			endif
 		endfor
@@ -454,7 +462,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 				if int_vars[i] != ''
 					let class = i.' class '
 				endif
-				let int_dict += [{'word':i, 'info':class.int_vars[i], 'kind':'v'}]
+				let int_dict += [{'word':i, 'info':class.int_vars[i], 'menu':class.int_vars[i], 'kind':'v'}]
 			else
 				let int_dict += [{'word':i, 'kind':'v'}]
 			endif
@@ -565,6 +573,7 @@ function! phpcomplete#CompletePHP(findstart, base)
 				let final_list +=
 						\ [{'word':i,
 						\   'info':i.int_functions[i],
+						\   'menu':i.int_functions[i],
 						\   'kind':'f'}]
 			elseif has_key(int_constants, i)
 				let final_list += [{'word':i, 'kind':'d'}]


### PR DESCRIPTION
By adding the same information under 'menu' key for the returned completion options, vim can show the function arguments and return type next to the completion options. I found this much more pleasing to use than the scratch window to look up the "is $haystack, $needle or $needle, $haystack" answers, because it's displayed right next to where i was typing just a moment ago. In practice, this is how it's looks like:

![menu_completion](https://f.cloud.github.com/assets/131617/403608/3f725064-a925-11e2-9d5c-cafbc972c5e5.png)

The commit also makes use of the "ClassName::__constuct(" entries of the g:php_builtin_object_functions dictionary when compleating class names. In action:
![menu_complete2](https://f.cloud.github.com/assets/131617/403616/93c4c71e-a925-11e2-9dbb-b33e27c454c6.png)

I've removed the requirement of "=" so the completion picks up the "new" keyword even when passing a new instance in a parameter and not assigning the result to anything.
