### PR TITLE
Replace vimgrep with taglist()

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -84,10 +84,11 @@ function! phpcomplete#CompletePHP(findstart, base)
 		endfor
 
 		" Prepare list of classes from tags file
+		let ext_classes = {}
 		let tags = taglist('^'.a:base)
 		for tag in tags
 			if tag.kind ==? 'c'
-				let ext_classes[item] = ''
+				let ext_classes[tag.name] = ''
 			endif
 		endfor
 


### PR DESCRIPTION
These commits replace vimgrep with the taglist() function. This way you can use the quickfix window while completing, Fixes #14.

Sorry for the mess in the commits, I've messed up the first commit while moving stuff around in branches and pushed up too early so can't rebase those commits to have a nice cerrypick. The real commit should have been mostly c1ccb0c.

I've tested every place where vimgrep was used one-by-one while replacing them, so I'm fairly confident in these changes, but please test them nonetheless.
