### PR TITLE
Show standard methods when I use ::

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -13,7 +13,7 @@
 "	  best situation
 
 if !exists('g:relax_static_constraint')
-	let g:relax_static_constraint = 1
+	let g:relax_static_constraint = 0
 endif
 
 function! phpcomplete#CompletePHP(findstart, base)


### PR DESCRIPTION
I need a way to show standard  methods when I use :: operator, so I add this.

just define the g:relax_static_constraint in your .vimrc like following:

```
let g:relax_static_constraint = 1
```
