### PR TITLE
Add Class::getClass() support

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -676,6 +676,12 @@ function! phpcomplete#GetClassName(scontext) " {{{
 				return classname
 			endif
 
+			" do in-file lookup for Class::getClass()
+			if line =~# '^\s*\$'.object.'\s*=&\?\s*\s\+\('.class_name_pattern.'\)::get\1'
+				let classname = matchlist(line, '\$'.object.'\s*=&\?\s*\s\+\('.class_name_pattern.'\)::get\1')[1]
+				return classname
+			endif
+
 			" do in-file lookup for static method invocation of a built-in class, like: $d = DateTime::createFromFormat()
 			if line =~# '^\s*\$'.object.'\s*=&\?\s*\s\+'.class_name_pattern.'::[a-zA-Z_0-9\x7f-\xff]\+('
 				let classname  = matchstr(line, '^\s*\$'.object.'\s*=&\?\s*\s\+\zs'.class_name_pattern.'\ze::[a-zA-Z_0-9\x7f-\xff]\+(')


### PR DESCRIPTION
I just open this pull request for discussion.

Currently, my code use Class::getClass() to get singleton instance. But phpomplete.vim only support Class::getInstance(). Does there any way to add this kind of stuff through plugins or configurations, instead of hacking the core?

You can see I have to add the following code to do this:

```
  " do in-file lookup for Class::getClass()
  if line =~# '^\s*\$'.object.'\s*=&\?\s*\s\+\('.class_name_pattern.'\)::get\1'
    let classname = matchlist(line, '\$'.object.'\s*=&\?\s*\s\+\('.class_name_pattern.'\)::get\1')[1]
    return classname
  endif 
```

Any ideas or suggestions?
