### PR TITLE
fix completion for classes starting with "use"

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -208,7 +208,7 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 
 	let [current_namespace, imports] = phpcomplete#GetCurrentNameSpace(getline(0, line('.')))
 
-	if context =~? '^use'
+	if context =~? '^use\s'
 		return phpcomplete#CompleteUse(a:base)
 	endif
 


### PR DESCRIPTION
if you initiate a completion for a class starting with "use" (User) the completion is built as if it was for "use" statement.

``` php
class User
{
    public static function staticMethod()
    {

    }
}

User::
```

you will get a list of all classes instead of a list of all static methods
