### PR TITLE
fix col_number

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -188,7 +188,7 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 				let start -= 1
 			endwhile
 			let b:phpbegin = phpbegin
-			let b:compl_context = phpcomplete#GetCurrentInstruction(line('.'), col('.') - 1, phpbegin)
+			let b:compl_context = phpcomplete#GetCurrentInstruction(line('.'), col('.') - 2, phpbegin)
 
 			" chop of the "base" from the end of the current instruction
 			let b:compl_context = substitute(b:compl_context, '\s*\$\?\([a-zA-Z_\x7f-\xff][a-zA-Z_0-9\x7f-\xff]*\)*$', '', '')


### PR DESCRIPTION
With some auto close plugin, when you type `if ($this->`, you will get `if ($this->)`.
Then you press `<Ctrl-X><Ctrl-O>`, the variable `b:compl_context` will be `if ($this->)`.
It will make `context =~ '\(->\|::\)$'` to be false.
