### PR TITLE
Added ability to search for functions that return-by-reference 

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -1053,12 +1053,12 @@ function! phpcomplete#LocateSymbol(symbol, symbol_context, symbol_namespace, cur
 			if filereadable(classlocation)
 				let classcontents = phpcomplete#GetCachedClassContents(classlocation, classname)
 				for classcontent in classcontents
-					if classcontent.content =~? 'function\_s\+\<'.search_symbol.'\(\>\|$\)' && filereadable(classcontent.file)
+					if classcontent.content =~? 'function\_s\+&\=\<'.search_symbol.'\(\>\|$\)' && filereadable(classcontent.file)
 						" Method found in classlocation
 						call s:readfileToTmpbuffer(classcontent.file)
 
 						call search('\cclass\_s\+\<'.classcontent.class.'\(\>\|$\)', 'wc')
-						call search('\cfunction\_s\+\zs\<'.search_symbol.'\(\>\|$\)', 'wc')
+						call search('\cfunction\_s\+&\=\zs\<'.search_symbol.'\(\>\|$\)', 'wc')
 
 						let line = line('.')
 						let col  = col('.')


### PR DESCRIPTION
phpcomplete#JumpToDefinition currently fails to jump to definition if it's one that does a return-by-reference e.g., function &test()
