### PR TITLE
fix: erratic initialization of tags

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -2614,6 +2614,9 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 						endfor
 					endif
 				endif
+				if exists('no_namespace_candidate')
+					unlet no_namespace_candidate
+				endif
 			endfor
 		endif
 		let i += 1


### PR DESCRIPTION
## Short version

phpcomplete#GetCurrentNameSpace(file_lines) returns a Dictionary
of duplicate values with different keys (one for each import)
to the main  phpcomplete#CompletePHP(findstart, base) function.

The author of the original code forgot to unsed the
'no_namespace_candidate' tag for each (tag in imports) iterations.
## Details

The values from 'no_namespace_candidate' were assignet do
all keys in the 'imports' dictionary.

This is a huge bug because if a .php file specified more
than one 'use dependency', they would all point to the file
and methods of the -last- use dependency.

I have reproduced the error in the tarball below. Try switching
the order of the two use statements and see what happens.

This is on a non-patched ctags.

list of software:

```
$ exuberant-ctags --version
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
  Compiled: Nov 15 2011, 20:02:35
  Addresses: <dhiebert@users.sourceforge.net>, http://ctags.sourceforge.net
  Optional compiled features: +wildcards, +regex

$ gvim --version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Sep 27 2014 14:49:31)
Included patches: 1-417
Modified by Gentoo-7.4.417
```
## Tarball (demonstrates bug)

$ tar -cv -f- project-complete/ | gzip  | base64
project-complete/
project-complete/Zumba.php
project-complete/autoload/
project-complete/autoload/autoload.php
project-complete/autoload/autoload.sh
project-complete/php.ctags
project-complete/make.php.ctags
project-complete/Do.php
project-complete/Group/
project-complete/Group/Task.php
H4sIABzlJlQAA+1a63PaOBDPV/RXbHPMQdIaYR7hrjnSZtr0MZM2HZr2Q0tKFFuAG2O7kpykj/zv
J8mYNyUPQueu+k0mCEm7K3u1q91FEQs/U0dYTtiLfCooXls+ihK1alV9lmrV4uhnijW7VLHt6pZd
KZfXinalulVcg+odrGUKMReEAax9JizkPjmbN2/R+H8U0aT+P8S9E1KIutHyZCgFb1Uqc/VfqlT7
+q9UirYt9b9VrthrUFzeEubjN9f/P4+kqlFAepRHxKHwLAy3EXJ8wjnorQDfUSaKT3zPgWwv5p6z
Pfzuhw4RXhgMu9px4Kge4F1ySvPZk9D9GhEmNuD75fQklwQOzc8e4yKMkqFL9Ktf0v8YU/ZPYhH6
IXGXeBBc3f/b5epWTdt/rWr8/yowX/9p4/ZnwQL/b8vdkepfBgDS/5eKtWLZ+P9VIPH/GMNjJ3S9
oPNWkMAlzOUvO0HI6DPPp+kofRKeUUY6NBmSM5lQY6LrcZB/JAC1Zzo0kLMEdaEticECN4QgFEBd
TyAe+a10Y7UY7XhcUJZHIJF6/nxWnz7S9etuBakioc4bPUA51CGIfX97MO61IT8crCfDowwURqgJ
Y+RrfmxUIScPv2bzOQvjqNk8JPw0B/UdyOFCAetOrPqUOeQezKHVJ+aQahhM5cYINoZLvxx7CE8u
UAwe5WPSONqYfBRGv8Qeo9BqPX3ZaLWgAJMkUwIukRQ6W5F7gWtO2N8VV/D/vHtLGYvO/1K5Ojz/
q1vK/1crJeP/V4E/7uETL8AnhHcRkv9pff3Y9ZhKCCBbPF5H1OmGkFUjyHH7DSQ9GjkBywrkDjmn
DKwv8osakqTSG4FFIbcpKBf4UP7bzAEUZG9pB7v0DCvnDD+QnAxWIB2lPoLwg2yUgx0YjTqMV7p7
TNm/fO8FR5AOX56MBfGftPqtYf6v6z8y/q8Y+18F7rUOd5+3nr3c32s9O2i82j3MlDKYXggauCqC
C1mPiG1p3EmrbsO5J61XxXMkiuQk2F4HEYLvBZRjNMLt7UHjcO9pxs7gYj0OeMhkRPgA7HraKtXb
oe860mekZG8aB88bu69au+8OXxw0Mk9llEYDeOHRE8pEBrvdpPU45pTxAg9j5lC5rA4tBFRMMnm9
+2ovs3cRSwoSCHiidnQGT85619jPdIWIHmKs9/wk1wwO223P8YgP3BNTK32/13j78uB1plr4S/FW
4WEGd8MexeluwVP2NR5JZvCnpNaiOrJ4ez3jIB00LuQzCC0HLPrlmj6XtPJyLUZXKeNo/mdJiWgh
85nZpBQ0O+AfZU1vx3xu1H8HMq4Qji9Z6ryE5w7EzE9JlixsTpKXSgmDxSKmbGtQqVTkKStddbyd
WQwLl5pnG7mUO8yL1OAtVjnCZbDYmJHbcu2zSFl2FvuEp2GfSbYjlCLoOYykxfmNG7Kydm5KJ4cd
RrjwAiLoUH5agL6RNofl6z43Xd6+GaukMt7nM7bYmytusNsmHn646+TAbYxCkadr1o7+bs6KNlIh
1mKNL34Rmk8+e96lwRj3MFoK8/4PDtdh+/MXMsFRrfuO3sIZ+hb3rmFTcnbfrvUTDC3qWmwi5gWi
xfIfISfpdN1LcT4acPvV0a3BIkwptyeNuLDcJHBh/d8up7//F21VJ7Jr5aL5/Xcl6Nd/eBf5Hhf1
496poL3oGHUpo/VjRokrU7tTAKsNhWPU9mTGl1VjYImvEYU2WLpU1NxUewak/Ss2iKaJl6V3ETRR
RjIY7Cr9/b3+v59Q6HYXcrpWrr9Y9MLxY5fWm+vNQscTzfWk+82LN9apXAav33c8t22dJd0+CTox
6VCVqDq0Lmcl/Yx26IUiqudwnpxwwYgjNh41+X0dZ8rP/MdPcHR/AzdL2MG5GVRJYPojJf6R+OMf
0nKEtBzqypZ3Jk/mDcVMviHiy8bGo9Rfq97mn7pLicprWRXcniVLulPK2sSho+uysTdrbjOb/0is
b7vWh9ZRv1G0/m4dbWqSs4RkB7DoRcOiTsEPO+gPa9+SCrUAoX55TyvtV29Fg1+AOYf7UmUsuv9T
rtYm7n9VtypF4/9XgeT336kLQF6gnS/kZmbtOTkDTaaG/cwQzczXEIq55t0cTt4e9OkYVM7Bmygh
B8AYQ7onObRZ2OvXtx7mEdrESGFGFKv754elxsdNYk7+sVQZ17j/UyvWitr+qyVz/2cVWJB/LkXG
Qv9fKg31r+9/1Uo14/9Xghn3PxMXPbgFqrYCGrkEOlqkRNNFRjReXkLjJdhZ9zzHqhk/uwh6hcKY
uSxqYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBg8NvhXwPAT4MAUAAA
