### PR TITLE
Added missing condition for jump with vsplit.

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -996,6 +996,8 @@ function! phpcomplete#JumpToDefinition(mode) " {{{
 	else
 		if a:mode == 'split'
 			silent! exec 'split | '.tag_position.'tag '.symbol
+		elseif a:mode == 'vsplit'
+			silent! exec 'vsplit | '.tag_position.'tag '.symbol
 		elseif a:mode == 'normal'
 			silent! exec tag_position.'tag '.symbol
 		endif


### PR DESCRIPTION
Hi,

Thanks for adding <C-[>. This is a good idea, but you probably missed adding one condition in JumpToDefinition (didn't work for me without this patch).

cheers
