### PR TITLE
Fixed ignorecase flag in namespace parsing

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -2701,7 +2701,7 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 			let use_parts = map(split(use_expression, '\s*,\s*'), 'substitute(v:val, "\\s+", " ", "g")')
 			for part in use_parts
 				if part =~? '\s\+as\s\+'
-					let [object, name] = split(part, '\s\+as\s\+')
+					let [object, name] = split(part, '\s\+as\s\+\c')
 					let object = substitute(object, '^\\', '', '')
 					let name   = substitute(name, '^\\', '', '')
 				else


### PR DESCRIPTION
Hi!

There was an error with uses written such way:
use Some\Path\To\Class AS SomeLocalName;
because "as" can be in any case and split by default is case-sensitive. From vimdoc about split():
`'ignorecase' is not used here, add \c to ignore case. |/\c|`