### PR TITLE
Fixed phpcomplete#JumpToDeffinition fail with cscopetag set

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -1009,6 +1009,8 @@ function! phpcomplete#JumpToDefinition(mode) " {{{
 	if tag_position == -1
 		silent! exec notfound_commands.symbol
 	else
+		let oldcscopetag = &cscopetag
+		set nocscopetag
 		if a:mode == 'split'
 			silent! exec 'split | '.tag_position.'tag '.symbol
 		elseif a:mode == 'vsplit'
@@ -1016,6 +1018,8 @@ function! phpcomplete#JumpToDefinition(mode) " {{{
 		elseif a:mode == 'normal'
 			silent! exec tag_position.'tag '.symbol
 		endif
+		let &cscopetag = oldcscopetag
+		unlet oldcscopetag
 	endif
 endfunction " }}}
 


### PR DESCRIPTION
Vim doesn't appear to support prefixing the :tag command with a number when cscopetag is set. Causing the jump to fail completely.

Patch turns off cscopetag and re-enables after execution as required.