### PR TITLE
Fixed splits changing their height

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -2307,7 +2307,7 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 	" remember the window we started at
 	let phpcomplete_original_window = winnr()
 
-	silent! below 1new
+	silent! tab 1new
 	silent! 0put =cfile
 	silent! exec "setlocal ft=phpcompletetempbuffer"
 
@@ -2648,7 +2648,7 @@ endfunction!
 function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 	let original_window = winnr()
 
-	silent! below 1new
+	silent! tab 1new
 	silent! 0put =a:file_lines
 	silent! exec "setlocal ft=phpcompletetempbuffer"
 	normal! G


### PR DESCRIPTION
Replacing `:below 1new` with `:tab 1 new` moves temporary windows
to their own tab so they are incapsulated in a kind of 'layout sandbox'.

This also fixes the problem with failing autocomplete in a 1-line split
by ensuring that the `:1new` command always has enough room (in its own
separate tab)