### PR TITLE
phpcomplete#GetClassName(): Avoid infinite loop

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -1808,14 +1808,11 @@ function! phpcomplete#GetClassName(start_line, context, current_namespace, impor
 				return ''
 			endif
 
-			if line =~? '\v^\s*(abstract\s+|final\s+)*\s*class'
+			if line =~? '\v^\s*(abstract\s+|final\s+)*\s*class\s'
 				let class_name = matchstr(line, '\c\s*class\s*\zs'.class_name_pattern.'\ze')
 				let extended_class = matchstr(line, '\cclass\s\+'.class_name_pattern.'\s\+extends\s\+\zs'.class_name_pattern.'\ze')
 
 				let classname_candidate = a:context =~? 'parent::' ? extended_class : class_name
-			else
-				let i += 1
-				continue
 			endif
 
 			if classname_candidate != ''
@@ -1823,6 +1820,8 @@ function! phpcomplete#GetClassName(start_line, context, current_namespace, impor
 				" return absolute classname, without leading \
 				return (class_candidate_namespace == '\' || class_candidate_namespace == '') ? classname_candidate : class_candidate_namespace.'\'.classname_candidate
 			endif
+
+			let i += 1
 		endwhile
 	elseif a:context =~? '(\s*new\s\+'.class_name_pattern.'\s*)->'
 		let classname_candidate = matchstr(a:context, '\cnew\s\+\zs'.class_name_pattern.'\ze')


### PR DESCRIPTION
Because of too much simple regexp to detect classes
it's not hard to get GetClassName() iterating forever.

This commit just adds a simple \s to the line regexp in
order to avoid some obvious false matches. And then moves
the inc to the end of the loop, so it will
happen always, ensuring the infinite loop won't happen ever.

I've tried also adding some "forbidden" chars to the line
regexp, but finally decided to abandon that route because
realized that somebody could be adding those chars in a comment
or other endless combinations.

Simple code examples heading to the infinite loop:

$var = 'Anything with a
       class will loop to the infinite'

$verylongvariablethatcausesnextlinetowrap =
    classname(...);

classify_is_a_nice_method_name_isnt_it(...);

And so on. This simple fix should avoid the problem.