### PR TITLE
Invalid index error fix when reading variables from certain classes

### DIFF
--- a/autoload/phpcomplete.vim
+++ b/autoload/phpcomplete.vim
@@ -1313,7 +1313,7 @@ function! phpcomplete#CompleteUserClass(context, base, sccontent, visibility) " 
 				let c_var = '$'.c_var
 			endif
 			let c_variables[c_var] = ''
-			if g:phpcomplete_parse_docblock_comments && len(get(variables, var_index)) > 0
+			if g:phpcomplete_parse_docblock_comments && len(get(variables, var_index, '')) > 0
 				let c_doc[c_var] = phpcomplete#GetDocBlock(a:sccontent, variables[var_index])
 			endif
 			let var_index += 1


### PR DESCRIPTION
This error prevented the omnicomplete popup to showup when hitting an out of index error while reading a class variables list. Solution was to add a default empty string '' to the get call since get returns zero (0) by default which len is 1, another option would be get(variables, var_index) != 0 but I just thought about that :)